### PR TITLE
Remove version from buildHead key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
   - "10"
 
 before_install:
-# package-lock.json was introduced in npm@5
-- '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
 - docker pull localstack/localstack
 - docker run -d --name localstack -p 4569:4569 --rm localstack/localstack
 
@@ -15,4 +13,4 @@ services:
   - docker
 matrix:
   fast_finish: true
-  
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [#12] Ignore version for `buildHead` key.
+ 
 ### 6.0.0
 - Convert datastar models to dynastar models
 - README update, synchronized readme with actual code, minor formatting
@@ -9,3 +11,4 @@
   - Update dependencies (minor/patch) to mitigate security warnings
 
 [#6]: https://github.com/warehouseai/warehouse-models/pull/6
+[#12]: https://github.com/warehouseai/warehouse-models/pull/12

--- a/lib/build-head.js
+++ b/lib/build-head.js
@@ -17,7 +17,7 @@ const Dynastar = require('dynastar');
  */
 module.exports = function buildHead(dynamo) {
   const createKey = (data) => {
-    return [data.name, data.env, data.version].join('!');
+    return [data.name, data.env].join('!');
   };
   const rangeKey = 'locale';
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -267,6 +267,20 @@ describe('registry-data (integration)', function () {
       });
     });
 
+    it('ignores version to always return latest', function (done) {
+      BuildHead.findOne({
+        name: 'email',
+        env: 'test',
+        locale: 'en-US',
+        version: '4.2' // is 2.1 in fixture
+      }, function (err, result) {
+        if (err) return done(err);
+        assume(err).is.falsey();
+        assume(result.version).eql(BuildHeadFixture.version);
+        done();
+      });
+    });
+
     it('deletes the build_head model', function (done) {
       BuildHead.remove(BuildHeadFixture, function (err) {
         assume(err).is.falsey();


### PR DESCRIPTION
## Summary

`BuildHead` should return data based on `name!env` key and ignore `version`. To always return the latest.

## Changelog

Done.

## Test Plan

Test added