### PR TITLE
[patch] do not copy falsy values to extended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [#13] Do not copy falsey values to `Package.extended`.
+
 ### 6.0.1
 
 - [#12] Ignore version for `buildHead` key.
@@ -14,3 +16,4 @@
 
 [#6]: https://github.com/warehouseai/warehouse-models/pull/6
 [#12]: https://github.com/warehouseai/warehouse-models/pull/12
+[#13]: https://github.com/warehouseai/warehouse-models/pull/13

--- a/lib/package.js
+++ b/lib/package.js
@@ -116,7 +116,7 @@ module.exports = function pkg(dynamo) {
     // object
     //
     replica.extended = difference(keys, schemaFields).reduce(function (acc, key) {
-      acc[key] = replica[key];
+      if (replica[key] || replica[key] === false) acc[key] = replica[key];
       delete replica[key];
       return acc;
     }, {});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -657,6 +657,28 @@ describe('registry-data (integration)', function () {
       });
     });
 
+    it('will not set falsy values on `extended`', function (done) {
+      const fixture = {
+        'dist-tags': {
+          latest: '0.0.1'
+        },
+        'versions': {
+          '0.0.1': {
+            author: '',
+            ...PackageFixture
+          }
+        }
+      };
+
+      const payload = Package.fromPublish(fixture);
+      assume(payload.extended).to.not.have.property('author');
+
+      Package.create(payload, function (err) {
+        assume(err).is.falsey();
+        done();
+      });
+    });
+
     it('returns an a falsey value for an unknown id', function (done) {
       Package.findOne({
         name: 'what'


### PR DESCRIPTION
## Summary

DynamoDB will throw on empty strings or falsy values do not copy irrelevant data. 

## Changelog

Added.

## Test Plan

Test added